### PR TITLE
Debug tweaks

### DIFF
--- a/enhanced_receiver.py
+++ b/enhanced_receiver.py
@@ -173,6 +173,7 @@ class WebSocketBridge:
 
 
 
+postamble = bytes.fromhex("e2 5c 4b 89 71 2e 25 c4 b8 97 12") * 11 + bytes.fromhex("00")
 
 
 class EnhancedMessageReceiver:
@@ -293,7 +294,18 @@ class EnhancedMessageReceiver:
             if station_bytes in self.block_list:
                 DebugConfig.debug_print(f"🚫 blocked frame from: {station_bytes.hex()}")
                 return
-
+            
+            # Step 1.1: discard dummy frames
+            if not any(fragment_payload):
+                DebugConfig.debug_print(f"🚫 discarded dummy frame from: {str(StationIdentifier.from_bytes(station_bytes))}")
+                return
+            
+            # Step 1.2: discard postamble frames
+            if fragment_payload == postamble:
+                DebugConfig.debug_print(f"🚫 discarded postamble frame from: {str(StationIdentifier.from_bytes(station_bytes))}")
+                # !!! ptw - need to actually process the postamble for timeline shutdown
+                return
+            
             # Step 2: Try to reassemble COBS frames
             cobs_frames = self.reassembler.add_frame_payload(fragment_payload)
 

--- a/radio_protocol.py
+++ b/radio_protocol.py
@@ -391,7 +391,7 @@ class COBSFrameBoundaryManager:
 
 		except Exception as e:
 			# Always show decode failures (they're important)
-			print(f"❌ COBS decode failed: {len(encoded_data)}B frame - {e}")
+			print(f"❌ COBS decode failed: {len(encoded_data)}B frame - {e} {decoded_frame.hex()}")
 			self.stats['decoding_errors'] += 1
 			raise ValueError(f"COBS decoding failed: {e}")
 


### PR DESCRIPTION
Eliminates the "IP frame too small for IP header" messages Interlocutor outputs for each dummy frame. Replaces them with debug_prints that say "discarded dummy frame".

Eliminates the "COBS decode failed" messages that Interlocutor outputs for each postamble frame. Replaces them with debug_prints that say "discarded postamble frame".

Adds a hex dump of the frame when COBS decode fails in decode_frame().