### PR TITLE
Recognize active Conda environments

### DIFF
--- a/interlocutor.py
+++ b/interlocutor.py
@@ -94,6 +94,8 @@ import random
 import sounddevice
 from dataclasses import dataclass
 
+from runtime_environment import isolated_environment_type
+
 from config_manager import (
 	OpulentVoiceConfig, 
 	ConfigurationManager, 
@@ -148,10 +150,11 @@ from interlocutor_commands import dispatcher as command_dispatcher
 # global variable for GUI
 web_interface_instance = None
 
-# check for virtual environment
-if not (hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)):
-	print("You need to run this code in a virtual environment:")
-	print("	 source /LED_test/bin/activate")
+# Check for an isolated Python environment.  Conda keeps sys.prefix equal to
+# sys.base_prefix, so the CPython venv check alone is not sufficient.
+if isolated_environment_type() is None:
+	print("You need to run this code in an isolated Python environment.")
+	print("Activate a venv/virtualenv or Conda environment before continuing.")
 	sys.exit(1)
 
 try: 

--- a/runtime_environment.py
+++ b/runtime_environment.py
@@ -1,0 +1,49 @@
+"""Helpers for identifying an isolated Python environment.
+
+Interlocutor depends on packages that should not be installed into the system
+Python.  CPython exposes a reliable signal for ``venv`` and ``virtualenv``,
+while Conda identifies its active prefix through ``CONDA_PREFIX``.
+"""
+
+import os
+import sys
+from typing import Any, Mapping, Optional
+
+
+def _same_prefix(left: str, right: str) -> bool:
+	"""Return whether two environment prefixes identify the same path."""
+	return os.path.normcase(os.path.realpath(left)) == os.path.normcase(
+		os.path.realpath(right)
+	)
+
+
+def isolated_environment_type(
+	sys_module: Any = sys,
+	environ: Optional[Mapping[str, str]] = None,
+) -> Optional[str]:
+	"""Return the active isolated-environment type, or ``None``.
+
+	Environment variables are accepted only when their prefix matches
+	``sys.prefix``.  This avoids treating a stale ``CONDA_PREFIX`` or
+	``VIRTUAL_ENV`` inherited by another interpreter as an active environment.
+	"""
+	if environ is None:
+		environ = os.environ
+
+	if getattr(sys_module, "real_prefix", None):
+		return "virtualenv"
+
+	prefix = getattr(sys_module, "prefix", "")
+	base_prefix = getattr(sys_module, "base_prefix", prefix)
+	if prefix and base_prefix and not _same_prefix(base_prefix, prefix):
+		return "venv"
+
+	for variable, environment_type in (
+		("CONDA_PREFIX", "conda"),
+		("VIRTUAL_ENV", "virtualenv"),
+	):
+		environment_prefix = environ.get(variable)
+		if environment_prefix and prefix and _same_prefix(environment_prefix, prefix):
+			return environment_type
+
+	return None

--- a/test_runtime_environment.py
+++ b/test_runtime_environment.py
@@ -1,0 +1,49 @@
+"""Tests for Python environment detection."""
+
+from types import SimpleNamespace
+import unittest
+
+from runtime_environment import isolated_environment_type
+
+
+class IsolatedEnvironmentTypeTest(unittest.TestCase):
+	def test_detects_standard_venv(self):
+		python = SimpleNamespace(prefix="/tmp/project/.venv", base_prefix="/usr")
+		self.assertEqual(isolated_environment_type(python, {}), "venv")
+
+	def test_detects_legacy_virtualenv(self):
+		python = SimpleNamespace(
+			prefix="/tmp/project/.venv",
+			base_prefix="/tmp/project/.venv",
+			real_prefix="/usr",
+		)
+		self.assertEqual(isolated_environment_type(python, {}), "virtualenv")
+
+	def test_detects_conda_environment_from_matching_prefix(self):
+		python = SimpleNamespace(
+			prefix="/opt/conda/envs/interlocutor",
+			base_prefix="/opt/conda/envs/interlocutor",
+		)
+		environ = {"CONDA_PREFIX": "/opt/conda/envs/interlocutor"}
+		self.assertEqual(isolated_environment_type(python, environ), "conda")
+
+	def test_detects_virtual_env_from_matching_prefix(self):
+		python = SimpleNamespace(
+			prefix="/tmp/project/.venv",
+			base_prefix="/tmp/project/.venv",
+		)
+		environ = {"VIRTUAL_ENV": "/tmp/project/.venv"}
+		self.assertEqual(isolated_environment_type(python, environ), "virtualenv")
+
+	def test_ignores_stale_environment_variable(self):
+		python = SimpleNamespace(prefix="/usr", base_prefix="/usr")
+		environ = {"CONDA_PREFIX": "/opt/conda/envs/interlocutor"}
+		self.assertIsNone(isolated_environment_type(python, environ))
+
+	def test_system_python_is_not_isolated(self):
+		python = SimpleNamespace(prefix="/usr", base_prefix="/usr")
+		self.assertIsNone(isolated_environment_type(python, {}))
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Summary

- recognize active Conda environments in addition to `venv` and legacy `virtualenv`
- require environment-provided prefixes to match `sys.prefix`, avoiding false positives from stale variables
- replace the machine-specific `/LED_test/bin/activate` instruction with environment-neutral guidance
- add regression coverage for standard venv, legacy virtualenv, Conda, stale environment variables, and system Python

## Root cause

The startup guard only compared `sys.prefix` and `sys.base_prefix`. Conda normally leaves those values equal and exposes the active environment through `CONDA_PREFIX`, so a valid Conda installation was rejected before Interlocutor could start.

Closes #102.

## Validation

- `python3 -m unittest -v test_runtime_environment.py`
- `python3 -m py_compile runtime_environment.py test_runtime_environment.py interlocutor.py`
- `git diff --check`
