### PR TITLE
Honor target mode CLI override

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -629,8 +629,10 @@ class ConfigurationManager:
 		# Protocol settings
 		if hasattr(args, 'target_type') and args.target_type is not None:
 			self.config.protocol.target_type = args.target_type
+			self.config.network.target_type = args.target_type
 		if hasattr(args, 'keepalive_interval') and args.keepalive_interval is not None:
 			self.config.protocol.keepalive_interval = args.keepalive_interval
+			self.config.network.keepalive_interval = args.keepalive_interval
 
 		# GPIO settings
 		if hasattr(args, 'ptt_pin') and args.ptt_pin is not None:
@@ -1267,9 +1269,11 @@ Configuration:
 	# Protocol settings
 	protocol_group = parser.add_argument_group('Protocol Settings')
 	protocol_group.add_argument(
-		'--target-type',
+		'--target-type', '--target-mode',
+		dest='target_type',
 		choices=['computer', 'modem'],
-		help='Target type: computer (LAN/Internet) or modem (SDR/Radio)'
+		help='Target type: computer (LAN/Internet) or modem (SDR/Radio); '
+			'--target-mode is accepted as a compatibility alias'
 	)
 	protocol_group.add_argument(
 		'--keepalive-interval',

--- a/test_config_manager.py
+++ b/test_config_manager.py
@@ -1,0 +1,38 @@
+import unittest
+
+from config_manager import ConfigurationManager, create_enhanced_argument_parser
+
+
+class TargetModeCliTests(unittest.TestCase):
+	def setUp(self):
+		self.parser = create_enhanced_argument_parser()
+
+	def test_target_mode_alias_selects_modem(self):
+		args = self.parser.parse_args(['N0CALL', '--target-mode', 'modem'])
+
+		self.assertEqual(args.target_type, 'modem')
+
+	def test_target_type_selects_modem(self):
+		args = self.parser.parse_args(['N0CALL', '--target-type', 'modem'])
+
+		self.assertEqual(args.target_type, 'modem')
+
+	def test_cli_target_mode_updates_both_config_views(self):
+		args = self.parser.parse_args([
+			'N0CALL',
+			'--target-mode', 'modem',
+			'--keepalive-interval', '3.5',
+		])
+		manager = ConfigurationManager()
+
+		config = manager.merge_cli_args(args)
+
+		self.assertEqual(config.protocol.target_type, 'modem')
+		self.assertEqual(config.network.target_type, 'modem')
+		self.assertEqual(config.protocol.keepalive_interval, 3.5)
+		self.assertEqual(config.network.keepalive_interval, 3.5)
+		self.assertEqual(config.to_dict()['network']['target_type'], 'modem')
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/web_interface.py
+++ b/web_interface.py
@@ -1293,6 +1293,8 @@ class EnhancedRadioWebInterface:
 						'target_port': self.config.network.target_port,
 						'listen_port': self.config.network.listen_port,
 						'encap_mode': self.config.network.encap_mode,
+						'target_type': self.config.network.target_type,
+						'keepalive_interval': self.config.network.keepalive_interval,
 						'voice_port': getattr(self.config.network, 'voice_port', 57373),
 						'text_port': getattr(self.config.network, 'text_port', 57374),
 						'control_port': getattr(self.config.network, 'control_port', 57375),
@@ -1427,6 +1429,12 @@ class EnhancedRadioWebInterface:
 					self.config.network.listen_port = int(network['listen_port'])
 				if 'encap_mode' in network:
 					self.config.network.encap_mode = network['encap_mode']
+				if 'target_type' in network:
+					self.config.network.target_type = network['target_type']
+					self.config.protocol.target_type = network['target_type']
+				if 'keepalive_interval' in network:
+					self.config.network.keepalive_interval = float(network['keepalive_interval'])
+					self.config.protocol.keepalive_interval = float(network['keepalive_interval'])
 				if 'voice_port' in network:
 					self.config.network.voice_port = int(network['voice_port'])
 				if 'text_port' in network:
@@ -1457,8 +1465,10 @@ class EnhancedRadioWebInterface:
 				protocol = data['protocol']
 				if 'target_type' in protocol:
 					self.config.protocol.target_type = protocol['target_type']
+					self.config.network.target_type = protocol['target_type']
 				if 'keepalive_interval' in protocol:
 					self.config.protocol.keepalive_interval = float(protocol['keepalive_interval'])
+					self.config.network.keepalive_interval = float(protocol['keepalive_interval'])
 				if 'continuous_stream' in protocol:
 					self.config.protocol.continuous_stream = bool(protocol['continuous_stream'])
 				updated_sections.append('protocol')
@@ -2170,6 +2180,12 @@ class EnhancedRadioWebInterface:
 				temp_config.network.listen_port = int(network['listen_port'])
 			if 'encap_mode' in network:
 				temp_config.network.encap_mode = network['encap_mode']
+			if 'target_type' in network:
+				temp_config.network.target_type = network['target_type']
+				temp_config.protocol.target_type = network['target_type']
+			if 'keepalive_interval' in network:
+				temp_config.network.keepalive_interval = float(network['keepalive_interval'])
+				temp_config.protocol.keepalive_interval = float(network['keepalive_interval'])
 		
 		if 'gpio' in form_config:
 			gpio = form_config['gpio']
@@ -2182,8 +2198,10 @@ class EnhancedRadioWebInterface:
 			protocol = form_config['protocol']
 			if 'target_type' in protocol:
 				temp_config.protocol.target_type = protocol['target_type']
+				temp_config.network.target_type = protocol['target_type']
 			if 'keepalive_interval' in protocol:
 				temp_config.protocol.keepalive_interval = float(protocol['keepalive_interval'])
+				temp_config.network.keepalive_interval = float(protocol['keepalive_interval'])
 		
 		if 'debug' in form_config:
 			debug = form_config['debug']


### PR DESCRIPTION
## Summary

- accept `--target-mode` as a compatibility alias for `--target-type`
- keep the v2 network and legacy protocol views of target settings synchronized
- include target mode settings in the configuration sent to the web UI
- add regression coverage for both CLI spellings and persisted v2 configuration

## Why

The CLI override previously updated only `config.protocol.target_type`, while v2 serialization and parts of the web UI read `config.network.target_type`. That left the two views disagreeing, so the UI could continue to show (and later save) `computer` after a modem override.

## Tests

- `/Users/daniilmordanov/anaconda3/bin/python -m unittest discover -v`
- `/Users/daniilmordanov/anaconda3/bin/python -m py_compile config_manager.py web_interface.py test_config_manager.py`
- `git diff --check`

Closes #112
